### PR TITLE
Fix CI dependencies for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y gcc-14 clang-16
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-14 clang-16 \
+            libx11-dev libxi-dev libxrandr-dev libxinerama-dev \
+            libxcursor-dev libxext-dev
+          python -m pip install cmake==3.29.2
       - name: Configure
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-14 clang-16 \
             libx11-dev libxi-dev libxrandr-dev libxinerama-dev \
-            libxcursor-dev libxext-dev
+            libxcursor-dev libxext-dev \
+            libgl1-mesa-dev libglu1-mesa-dev
           python -m pip install cmake==3.29.2
       - name: Configure
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 
 # debug information files
 *.dwo
+build/


### PR DESCRIPTION
## Summary
- add X11 packages and Python cmake install in CI
- ignore build directory

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687cefe358e8832ca80abe2c7e78a0a6