### PR TITLE
Implement ECS core and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,3 +27,14 @@ target_include_directories(x2d PUBLIC engine)
 x2d_enable_strict_warnings(x2d)
 
 enable_testing()
+
+FetchContent_Declare(catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.5.3)
+FetchContent_MakeAvailable(catch2)
+
+file(GLOB TEST_SRC CONFIGURE_DEPENDS tests/*Test.cpp)
+add_executable(x2d_tests ${TEST_SRC})
+target_link_libraries(x2d_tests PRIVATE Catch2::Catch2WithMain x2d)
+x2d_enable_strict_warnings(x2d_tests)
+add_test(NAME x2d_tests COMMAND x2d_tests)

--- a/engine/ECS/ComponentStorage.hpp
+++ b/engine/ECS/ComponentStorage.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <vector>
+#include <algorithm>
+#include <type_traits>
+#include <cstdint>
+
+#include "Entity.hpp"
+#include "TypeTraits.hpp"
+
+namespace x2d
+{
+
+namespace detail
+{
+template<class T>
+struct StorageType
+{
+    using Type = T;
+};
+
+template<class T>
+struct StorageType<OneFrame<T>>
+{
+    using Type = T;
+};
+} // namespace detail
+
+class IComponentStorage
+{
+public:
+    virtual ~IComponentStorage() = default;
+    virtual void RemoveEntity(Entity entity) = 0;
+    virtual void ClearIfOneFrame() = 0;
+};
+
+template<class TComponent>
+class ComponentStorage final : public IComponentStorage
+{
+public:
+    using Stored = typename detail::StorageType<TComponent>::Type;
+    static_assert(std::is_trivial_v<Stored> && std::is_standard_layout_v<Stored>, "Component must be POD");
+
+    Stored& Add(Entity entity, const Stored& component)
+    {
+        const std::uint32_t index = GetIndex(entity);
+        if (m_Sparse.size() <= index)
+        {
+            m_Sparse.resize(index + 1, InvalidIndex);
+        }
+        const std::uint32_t denseIndex = static_cast<std::uint32_t>(m_Dense.size());
+        m_Dense.push_back(component);
+        m_Entities.push_back(entity);
+        m_Sparse[index] = denseIndex;
+        return m_Dense.back();
+    }
+
+    bool Has(Entity entity) const
+    {
+        const std::uint32_t index = GetIndex(entity);
+        if (index >= m_Sparse.size())
+        {
+            return false;
+        }
+        const std::uint32_t denseIndex = m_Sparse[index];
+        return denseIndex != InvalidIndex && denseIndex < m_Dense.size() && m_Entities[denseIndex] == entity;
+    }
+
+    Stored& Get(Entity entity)
+    {
+        const std::uint32_t denseIndex = m_Sparse[GetIndex(entity)];
+        return m_Dense[denseIndex];
+    }
+
+    void Remove(Entity entity) override
+    {
+        const std::uint32_t index = GetIndex(entity);
+        if (index >= m_Sparse.size())
+        {
+            return;
+        }
+        const std::uint32_t denseIndex = m_Sparse[index];
+        if (denseIndex == InvalidIndex || m_Entities[denseIndex] != entity)
+        {
+            return;
+        }
+        const std::uint32_t last = static_cast<std::uint32_t>(m_Dense.size() - 1);
+        if (denseIndex != last)
+        {
+            m_Dense[denseIndex] = m_Dense[last];
+            m_Entities[denseIndex] = m_Entities[last];
+            m_Sparse[GetIndex(m_Entities[denseIndex])] = denseIndex;
+        }
+        m_Dense.pop_back();
+        m_Entities.pop_back();
+        m_Sparse[index] = InvalidIndex;
+    }
+
+    void RemoveEntity(Entity entity)
+    {
+        Remove(entity);
+    }
+
+    void ClearIfOneFrame() override
+    {
+        if constexpr (IsOneFrame<TComponent>::value)
+        {
+            m_Dense.clear();
+            m_Entities.clear();
+            std::fill(m_Sparse.begin(), m_Sparse.end(), InvalidIndex);
+        }
+    }
+
+private:
+    static constexpr std::uint32_t InvalidIndex = 0xFFFFFFFFU;
+    std::vector<Stored> m_Dense{};
+    std::vector<Entity> m_Entities{};
+    std::vector<std::uint32_t> m_Sparse{};
+};
+
+} // namespace x2d
+

--- a/engine/ECS/DamageEventComponent.hpp
+++ b/engine/ECS/DamageEventComponent.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace x2d
+{
+
+struct alignas(16) DamageEventComponent
+{
+    int amount{0};
+};
+static_assert(sizeof(DamageEventComponent) <= 64);
+
+} // namespace x2d
+

--- a/engine/ECS/Entity.hpp
+++ b/engine/ECS/Entity.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+
+namespace x2d
+{
+
+using Entity = std::uint32_t;
+
+inline constexpr std::uint32_t s_IndexBits = 22U;
+inline constexpr std::uint32_t s_GenerationBits = 10U;
+inline constexpr std::uint32_t s_IndexMask = (1U << s_IndexBits) - 1U;
+inline constexpr std::uint32_t s_GenerationMask = (1U << s_GenerationBits) - 1U;
+
+inline constexpr Entity MakeEntity(std::uint32_t index, std::uint32_t generation)
+{
+    return (generation << s_IndexBits) | index;
+}
+
+inline constexpr std::uint32_t GetIndex(Entity entity)
+{
+    return entity & s_IndexMask;
+}
+
+inline constexpr std::uint32_t GetGeneration(Entity entity)
+{
+    return (entity >> s_IndexBits) & s_GenerationMask;
+}
+
+} // namespace x2d
+

--- a/engine/ECS/EntityManager.cpp
+++ b/engine/ECS/EntityManager.cpp
@@ -1,0 +1,61 @@
+#include "EntityManager.hpp"
+
+namespace x2d
+{
+
+Entity EntityManager::CreateEntity()
+{
+    std::uint32_t index;
+    if (!m_FreeList.empty())
+    {
+        index = m_FreeList.back();
+        m_FreeList.pop_back();
+    }
+    else
+    {
+        index = static_cast<std::uint32_t>(m_Generations.size());
+        m_Generations.push_back(0);
+    }
+
+    ++m_Alive;
+    const std::uint16_t generation = m_Generations[index];
+    return MakeEntity(index, generation);
+}
+
+void EntityManager::DestroyEntity(Entity entity)
+{
+    const std::uint32_t index = GetIndex(entity);
+    if (index >= m_Generations.size())
+    {
+        return;
+    }
+
+    ++m_Generations[index];
+    m_Generations[index] &= s_GenerationMask;
+    m_FreeList.push_back(index);
+    --m_Alive;
+}
+
+bool EntityManager::IsAlive(Entity entity) const
+{
+    const std::uint32_t index = GetIndex(entity);
+    const std::uint16_t generation = GetGeneration(entity);
+    return index < m_Generations.size() && m_Generations[index] == generation;
+}
+
+std::size_t EntityManager::AliveCount() const
+{
+    return m_Alive;
+}
+
+std::uint16_t EntityManager::GetGenerationForIndex(std::uint32_t index) const
+{
+    if (index < m_Generations.size())
+    {
+        return m_Generations[index];
+    }
+    return 0;
+}
+
+} // namespace x2d
+

--- a/engine/ECS/EntityManager.hpp
+++ b/engine/ECS/EntityManager.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <vector>
+
+#include "Entity.hpp"
+
+namespace x2d
+{
+
+class EntityManager final
+{
+public:
+    EntityManager() = default;
+
+    [[nodiscard]] Entity CreateEntity();
+    void DestroyEntity(Entity entity);
+    [[nodiscard]] bool IsAlive(Entity entity) const;
+    [[nodiscard]] std::size_t AliveCount() const;
+
+    [[nodiscard]] std::uint16_t GetGenerationForIndex(std::uint32_t index) const;
+
+private:
+    std::vector<std::uint16_t> m_Generations;
+    std::vector<std::uint32_t> m_FreeList;
+    std::size_t m_Alive{0};
+};
+
+} // namespace x2d
+

--- a/engine/ECS/OneFrame.hpp
+++ b/engine/ECS/OneFrame.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace x2d
+{
+
+template<class T>
+struct OneFrame
+{
+    T value;
+};
+
+} // namespace x2d
+

--- a/engine/ECS/Signature.hpp
+++ b/engine/ECS/Signature.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <bitset>
+#include <cstddef>
+
+namespace x2d
+{
+
+using Signature = std::bitset<64>;
+
+inline std::size_t NextComponentTypeId()
+{
+    static std::size_t s_Next = 0;
+    return s_Next++;
+}
+
+template<class T>
+[[nodiscard]] inline std::size_t ComponentTypeId()
+{
+    static const std::size_t id = NextComponentTypeId();
+    return id;
+}
+
+} // namespace x2d
+

--- a/engine/ECS/System.hpp
+++ b/engine/ECS/System.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+
+#include "Entity.hpp"
+
+namespace x2d
+{
+
+struct View
+{
+    const Entity* entities{nullptr};
+    std::size_t count{0};
+};
+
+class ISystem
+{
+public:
+    virtual ~ISystem() = default;
+    virtual void Update(const View& view) = 0;
+};
+
+} // namespace x2d
+

--- a/engine/ECS/SystemManager.cpp
+++ b/engine/ECS/SystemManager.cpp
@@ -1,0 +1,30 @@
+#include "SystemManager.hpp"
+
+#include "World.hpp"
+
+namespace x2d
+{
+
+void SystemManager::BuildViews(const World& world)
+{
+    for (auto& entry : m_Systems)
+    {
+        entry.entityBuffer.clear();
+        const auto& signatures = world.GetSignatures();
+        entry.entityBuffer.reserve(signatures.size());
+        for (std::size_t i = 0; i < signatures.size(); ++i)
+        {
+            const Signature& sig = signatures[i];
+            if ((sig & entry.signature) == entry.signature)
+            {
+                const std::uint16_t gen = world.GetGenerationForIndex(static_cast<std::uint32_t>(i));
+                entry.entityBuffer.push_back(MakeEntity(static_cast<std::uint32_t>(i), gen));
+            }
+        }
+        entry.view.entities = entry.entityBuffer.data();
+        entry.view.count = entry.entityBuffer.size();
+    }
+}
+
+} // namespace x2d
+

--- a/engine/ECS/SystemManager.hpp
+++ b/engine/ECS/SystemManager.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "Signature.hpp"
+#include "System.hpp"
+#include "WorldFwd.hpp"
+
+namespace x2d
+{
+
+class SystemManager final
+{
+public:
+    template<class TSystem, class... Args>
+    TSystem& RegisterSystem(const Signature& signature, Args&&... args)
+    {
+        auto sys = std::make_unique<TSystem>(std::forward<Args>(args)...);
+        m_Systems.push_back({std::move(sys), signature, {}});
+        return *static_cast<TSystem*>(m_Systems.back().system.get());
+    }
+
+    void BuildViews(const World& world);
+
+    template<class Func>
+    void ForEachSystem(Func func)
+    {
+        for (auto& entry : m_Systems)
+        {
+            func(*entry.system, entry.view);
+        }
+    }
+
+private:
+    struct Entry
+    {
+        std::unique_ptr<ISystem> system;
+        Signature signature;
+        View view;
+        std::vector<Entity> entityBuffer;
+    };
+
+    std::vector<Entry> m_Systems;
+};
+
+} // namespace x2d
+

--- a/engine/ECS/TransformComponent.hpp
+++ b/engine/ECS/TransformComponent.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+namespace x2d
+{
+
+struct alignas(16) TransformComponent
+{
+    float x{0.0f};
+    float y{0.0f};
+    float rotation{0.0f};
+    float scale{1.0f};
+};
+static_assert(sizeof(TransformComponent) <= 64);
+
+} // namespace x2d
+

--- a/engine/ECS/TypeTraits.hpp
+++ b/engine/ECS/TypeTraits.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <type_traits>
+
+#include "OneFrame.hpp"
+
+namespace x2d
+{
+
+template<class T>
+struct IsOneFrame : std::false_type
+{
+};
+
+template<class T>
+struct IsOneFrame<OneFrame<T>> : std::true_type
+{
+    using Wrapped = T;
+};
+
+} // namespace x2d
+

--- a/engine/ECS/VelocityComponent.hpp
+++ b/engine/ECS/VelocityComponent.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace x2d
+{
+
+struct alignas(16) VelocityComponent
+{
+    float vx{0.0f};
+    float vy{0.0f};
+};
+static_assert(sizeof(VelocityComponent) <= 64);
+
+} // namespace x2d
+

--- a/engine/ECS/World.cpp
+++ b/engine/ECS/World.cpp
@@ -1,0 +1,53 @@
+#include "World.hpp"
+
+namespace x2d
+{
+
+World::World() = default;
+
+Entity World::CreateEntity()
+{
+    const Entity entity = m_EntityManager.CreateEntity();
+    const std::uint32_t index = GetIndex(entity);
+    if (m_Signatures.size() <= index)
+    {
+        m_Signatures.resize(index + 1);
+    }
+    m_Signatures[index].reset();
+    return entity;
+}
+
+void World::DestroyEntity(Entity entity)
+{
+    m_EntityManager.DestroyEntity(entity);
+    const std::uint32_t index = GetIndex(entity);
+    if (index < m_Signatures.size())
+    {
+        m_Signatures[index].reset();
+    }
+    for (auto& [id, storage] : m_Storages)
+    {
+        storage->RemoveEntity(entity);
+    }
+}
+
+const std::vector<Signature>& World::GetSignatures() const
+{
+    return m_Signatures;
+}
+
+std::uint16_t World::GetGenerationForIndex(std::uint32_t index) const
+{
+    return m_EntityManager.GetGenerationForIndex(index);
+}
+
+void World::EndFrame()
+{
+    for (auto& [id, storage] : m_Storages)
+    {
+        storage->ClearIfOneFrame();
+    }
+}
+
+} // namespace x2d
+

--- a/engine/ECS/World.hpp
+++ b/engine/ECS/World.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "ComponentStorage.hpp"
+#include "EntityManager.hpp"
+#include "Signature.hpp"
+#include "SystemManager.hpp"
+
+namespace x2d
+{
+
+class World final
+{
+public:
+    World();
+
+    [[nodiscard]] Entity CreateEntity();
+    void DestroyEntity(Entity entity);
+
+    template<class TComponent>
+    TComponent& AddComponent(Entity entity, const typename ComponentStorage<TComponent>::Stored& component)
+    {
+        auto& storage = GetOrCreateStorage<TComponent>();
+        m_Signatures[GetIndex(entity)].set(ComponentTypeId<TComponent>());
+        return storage.Add(entity, component);
+    }
+
+    template<class TComponent>
+    void RemoveComponent(Entity entity)
+    {
+        auto* storage = GetStorage<TComponent>();
+        if (storage == nullptr)
+        {
+            return;
+        }
+        storage->RemoveEntity(entity);
+        m_Signatures[GetIndex(entity)].reset(ComponentTypeId<TComponent>());
+    }
+
+    template<class TComponent>
+    [[nodiscard]] bool HasComponent(Entity entity) const
+    {
+        const auto* storage = GetStorage<TComponent>();
+        return storage != nullptr && storage->Has(entity);
+    }
+
+    [[nodiscard]] const std::vector<Signature>& GetSignatures() const;
+    [[nodiscard]] std::uint16_t GetGenerationForIndex(std::uint32_t index) const;
+
+    void EndFrame();
+
+private:
+    template<class TComponent>
+    ComponentStorage<TComponent>& GetOrCreateStorage()
+    {
+        const std::size_t id = ComponentTypeId<TComponent>();
+        auto it = m_Storages.find(id);
+        if (it == m_Storages.end())
+        {
+            auto storage = std::make_unique<ComponentStorage<TComponent>>();
+            auto* ptr = storage.get();
+            m_Storages.emplace(id, std::move(storage));
+            return *ptr;
+        }
+        return *static_cast<ComponentStorage<TComponent>*>(it->second.get());
+    }
+
+    template<class TComponent>
+    ComponentStorage<TComponent>* GetStorage() const
+    {
+        const std::size_t id = ComponentTypeId<TComponent>();
+        auto it = m_Storages.find(id);
+        if (it == m_Storages.end())
+        {
+            return nullptr;
+        }
+        return static_cast<ComponentStorage<TComponent>*>(it->second.get());
+    }
+
+    EntityManager m_EntityManager;
+    std::unordered_map<std::size_t, std::unique_ptr<IComponentStorage>> m_Storages;
+    std::vector<Signature> m_Signatures;
+    SystemManager m_SystemManager;
+};
+
+} // namespace x2d
+

--- a/engine/ECS/WorldFwd.hpp
+++ b/engine/ECS/WorldFwd.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace x2d
+{
+class World;
+}
+

--- a/tests/EcsTest.cpp
+++ b/tests/EcsTest.cpp
@@ -1,0 +1,65 @@
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+
+#include "engine/ECS/World.hpp"
+#include "engine/ECS/TransformComponent.hpp"
+#include "engine/ECS/VelocityComponent.hpp"
+#include "engine/ECS/DamageEventComponent.hpp"
+#include "engine/ECS/OneFrame.hpp"
+
+using namespace x2d;
+
+TEST_CASE("Entity creation/destruction performance", "[ecs]")
+{
+    World world;
+    constexpr std::size_t count = 1'000'000;
+    auto start = std::chrono::high_resolution_clock::now();
+    std::vector<Entity> entities;
+    entities.reserve(count);
+    for (std::size_t i = 0; i < count; ++i)
+    {
+        entities.push_back(world.CreateEntity());
+    }
+    for (auto e : entities)
+    {
+        world.DestroyEntity(e);
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    REQUIRE(ms < 50);
+}
+
+TEST_CASE("Signature updates", "[ecs]")
+{
+    World world;
+    Entity e = world.CreateEntity();
+    world.AddComponent<TransformComponent>(e, {});
+    world.AddComponent<VelocityComponent>(e, {});
+    const auto& sig = world.GetSignatures()[GetIndex(e)];
+    REQUIRE(sig.test(ComponentTypeId<TransformComponent>()));
+    REQUIRE(sig.test(ComponentTypeId<VelocityComponent>()));
+}
+
+TEST_CASE("Swap erase integrity", "[ecs]")
+{
+    World world;
+    Entity e1 = world.CreateEntity();
+    Entity e2 = world.CreateEntity();
+    world.AddComponent<TransformComponent>(e1, {1.0f,2.0f,0.0f,1.0f});
+    world.AddComponent<TransformComponent>(e2, {3.0f,4.0f,0.0f,1.0f});
+
+    world.RemoveComponent<TransformComponent>(e1);
+    REQUIRE_FALSE(world.HasComponent<TransformComponent>(e1));
+    REQUIRE(world.HasComponent<TransformComponent>(e2));
+}
+
+TEST_CASE("OneFrame clearing", "[ecs]")
+{
+    World world;
+    Entity e = world.CreateEntity();
+    world.AddComponent<OneFrame<DamageEventComponent>>(e, {10});
+    REQUIRE(world.HasComponent<OneFrame<DamageEventComponent>>(e));
+    world.EndFrame();
+    REQUIRE_FALSE(world.HasComponent<OneFrame<DamageEventComponent>>(e));
+}
+


### PR DESCRIPTION
## Summary
- add `Entity` utilities and `EntityManager`
- implement `ComponentStorage` with swap-pop removal and one-frame support
- introduce `Signature` bitset and `SystemManager` with view construction
- provide `World` facade and POD components
- integrate Catch2 and add ECS unit tests

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release` *(fails: CMake 3.29 required)*

------
https://chatgpt.com/codex/tasks/task_e_687cf5efcd68832cb981eeba33574605