### PR TITLE
Implement cross-platform hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.29)
 project(X2D LANGUAGES CXX VERSION 1.0.0)
 
+set(SUPPORTED_PLATFORMS DESKTOP WEB PS XBOX SWITCH)
+set(X2D_PLATFORM "DESKTOP" CACHE STRING "Target platform")
+set_property(CACHE X2D_PLATFORM PROPERTY STRINGS ${SUPPORTED_PLATFORMS})
+list(FIND SUPPORTED_PLATFORMS ${X2D_PLATFORM} idx)
+if(idx EQUAL -1)
+    message(FATAL_ERROR "Invalid X2D_PLATFORM: ${X2D_PLATFORM}")
+endif()
+string(TOUPPER "${X2D_PLATFORM}" X2D_PLATFORM_UPPER)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -13,16 +22,28 @@ FetchContent_Declare(raylib
     GIT_REPOSITORY https://github.com/raysan5/raylib.git
     GIT_TAG 5.5)
 set(BUILD_SHARED_LIBS OFF)
-set(PLATFORM_DESKTOP ON)
+if(X2D_PLATFORM_UPPER STREQUAL "WEB")
+    set(PLATFORM_WEB ON)
+    set(PLATFORM_DESKTOP OFF)
+else()
+    set(PLATFORM_DESKTOP ON)
+endif()
 FetchContent_MakeAvailable(raylib)
 
 add_library(x2d STATIC)
 file(GLOB_RECURSE X2D_SRC CONFIGURE_DEPENDS engine/*.cpp)
+foreach(p ${SUPPORTED_PLATFORMS})
+    if(NOT X2D_PLATFORM_UPPER STREQUAL p)
+        list(FILTER X2D_SRC EXCLUDE REGEX "engine/Platform/${p}/.*\\.cpp")
+    endif()
+endforeach()
 target_sources(x2d PRIVATE ${X2D_SRC})
 
 target_link_libraries(x2d PUBLIC raylib)
 
 target_include_directories(x2d PUBLIC engine)
+
+target_compile_definitions(x2d PUBLIC X2D_PLATFORM_${X2D_PLATFORM_UPPER})
 
 x2d_enable_strict_warnings(x2d)
 
@@ -37,4 +58,5 @@ file(GLOB TEST_SRC CONFIGURE_DEPENDS tests/*Test.cpp)
 add_executable(x2d_tests ${TEST_SRC})
 target_link_libraries(x2d_tests PRIVATE Catch2::Catch2WithMain x2d)
 x2d_enable_strict_warnings(x2d_tests)
+target_compile_definitions(x2d_tests PRIVATE X2D_PLATFORM_${X2D_PLATFORM_UPPER})
 add_test(NAME x2d_tests COMMAND x2d_tests)

--- a/engine/Platform/Desktop/WindowSystem.cpp
+++ b/engine/Platform/Desktop/WindowSystem.cpp
@@ -1,4 +1,4 @@
-#include "WindowSystem.hpp"
+#include "Platform/WindowSystem.hpp"
 
 #include "ECS/World.hpp"
 

--- a/engine/Platform/PS/WindowSystem.cpp
+++ b/engine/Platform/PS/WindowSystem.cpp
@@ -1,0 +1,16 @@
+#include "Platform/WindowSystem.hpp"
+
+namespace x2d
+{
+
+WindowSystem::WindowSystem(int, int, std::string)
+{
+}
+
+WindowSystem::~WindowSystem() = default;
+
+void WindowSystem::Update(const View&)
+{
+}
+
+} // namespace x2d

--- a/engine/Platform/Switch/WindowSystem.cpp
+++ b/engine/Platform/Switch/WindowSystem.cpp
@@ -1,0 +1,16 @@
+#include "Platform/WindowSystem.hpp"
+
+namespace x2d
+{
+
+WindowSystem::WindowSystem(int, int, std::string)
+{
+}
+
+WindowSystem::~WindowSystem() = default;
+
+void WindowSystem::Update(const View&)
+{
+}
+
+} // namespace x2d

--- a/engine/Platform/Web/WindowSystem.cpp
+++ b/engine/Platform/Web/WindowSystem.cpp
@@ -1,0 +1,38 @@
+#include "Platform/WindowSystem.hpp"
+
+#include "ECS/World.hpp"
+
+namespace x2d
+{
+
+WindowSystem::WindowSystem(int width, int height, std::string title)
+{
+    InitWindow(width, height, title.c_str());
+    SetTargetFPS(60);
+    m_Initialized = true;
+}
+
+WindowSystem::~WindowSystem()
+{
+    if (m_Initialized)
+    {
+        CloseWindow();
+    }
+}
+
+void WindowSystem::Update(const View&)
+{
+    if (m_World == nullptr)
+    {
+        return;
+    }
+    if (IsWindowResized())
+    {
+        const int w = GetScreenWidth();
+        const int h = GetScreenHeight();
+        Entity e = m_World->CreateEntity();
+        m_World->AddComponent<OneFrame<WindowResizeEventComponent>>(e, {w, h});
+    }
+}
+
+} // namespace x2d

--- a/engine/Platform/Xbox/WindowSystem.cpp
+++ b/engine/Platform/Xbox/WindowSystem.cpp
@@ -1,0 +1,16 @@
+#include "Platform/WindowSystem.hpp"
+
+namespace x2d
+{
+
+WindowSystem::WindowSystem(int, int, std::string)
+{
+}
+
+WindowSystem::~WindowSystem() = default;
+
+void WindowSystem::Update(const View&)
+{
+}
+
+} // namespace x2d


### PR DESCRIPTION
## Summary
- add `X2D_PLATFORM` option
- move desktop window system to a platform folder
- stub out console window systems
- duplicate desktop window system for web builds
- pass platform defines to targets

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687d34ddcc50832cb899d0763a7cd970