### PR TITLE
Align CMake version with project policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             libx11-dev libxi-dev libxrandr-dev libxinerama-dev \
             libxcursor-dev libxext-dev \
             libgl1-mesa-dev libglu1-mesa-dev
-          python -m pip install cmake==3.29.2
+          python -m pip install cmake==3.28.3
       - name: Configure
         run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.28.3)
 project(X2D LANGUAGES CXX VERSION 1.0.0)
 
 set(SUPPORTED_PLATFORMS DESKTOP WEB PS XBOX SWITCH)

--- a/scripts/install_toolchains.sh
+++ b/scripts/install_toolchains.sh
@@ -6,8 +6,8 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   sudo apt-get install -y gcc-14 clang-16
   echo "GCC 14 and Clang 16 installed."
   # Ensure recent CMake required by the project
-  pip install --upgrade --quiet cmake==3.29.0
-  echo "CMake 3.29 installed via pip."
+  pip install --upgrade --quiet cmake==3.28.3
+  echo "CMake 3.28.3 installed via pip."
 elif [[ "$OS" == "Windows_NT" ]]; then
   echo "Please install MSVC 19.38 via Visual Studio Installer." >&2
 else


### PR DESCRIPTION
## Summary
- drop CMake 3.29 requirement
- update CI and toolchain scripts to use version 3.28.3

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target x2d_tests --config Release -j4`
- `ctest --test-dir build --output-on-failure -C Release`


------
https://chatgpt.com/codex/tasks/task_e_687dafdbb8d0832ca7eaa1a3b4672e6f