### PR TITLE
Fix CI issues with raylib tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(FetchContent)
 #Raylib
 FetchContent_Declare(raylib
     GIT_REPOSITORY https://github.com/raysan5/raylib.git
-    GIT_TAG 5.1.0)
+    GIT_TAG 5.5)
 set(BUILD_SHARED_LIBS OFF)
 if(X2D_PLATFORM_UPPER STREQUAL "WEB")
     set(PLATFORM_WEB ON)

--- a/examples/platformer/CMakeLists.txt
+++ b/examples/platformer/CMakeLists.txt
@@ -11,5 +11,6 @@ add_executable(
 )
 
 target_link_libraries(platformer PRIVATE x2d)
+target_include_directories(platformer PRIVATE ${CMAKE_SOURCE_DIR})
 target_compile_definitions(platformer PRIVATE X2D_PLATFORM_${X2D_PLATFORM_UPPER})
 x2d_enable_strict_warnings(platformer)


### PR DESCRIPTION
## Summary
- update raylib version to tag 5.5
- ensure platformer example can find its headers

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target platformer`
- `cmake --build build --target x2d_tests`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687dbfeebe20832c98f41b9db1219298