### PR TITLE
fix: remove using namespace from tests

### DIFF
--- a/tests/AssetLoaderTest.cpp
+++ b/tests/AssetLoaderTest.cpp
@@ -4,10 +4,8 @@
 #include <chrono>
 #include <thread>
 
-using namespace x2d;
-
 TEST_CASE("AssetLoader caches by path") {
-    AssetLoader loader(1);
+    x2d::AssetLoader loader(1);
     auto future1 = loader.Load<int>("foo", [](const std::string &) { return 42; });
     auto future2 = loader.Load<int>("foo", [](const std::string &) { return 43; });
     REQUIRE(future1.get() == future2.get());

--- a/tests/EcsTest.cpp
+++ b/tests/EcsTest.cpp
@@ -7,14 +7,12 @@
 #include "ECS/DamageEventComponent.hpp"
 #include "ECS/OneFrame.hpp"
 
-using namespace x2d;
-
 TEST_CASE("Entity creation/destruction performance", "[ecs]")
 {
-    World world;
+    x2d::World world;
     constexpr std::size_t count = 1'000'000;
     auto start = std::chrono::high_resolution_clock::now();
-    std::vector<Entity> entities;
+    std::vector<x2d::Entity> entities;
     entities.reserve(count);
     for (std::size_t i = 0; i < count; ++i)
     {
@@ -31,35 +29,35 @@ TEST_CASE("Entity creation/destruction performance", "[ecs]")
 
 TEST_CASE("Signature updates", "[ecs]")
 {
-    World world;
-    Entity e = world.CreateEntity();
-    world.AddComponent<TransformComponent>(e, {});
-    world.AddComponent<VelocityComponent>(e, {});
-    const auto& sig = world.GetSignatures()[GetIndex(e)];
-    REQUIRE(sig.test(ComponentTypeId<TransformComponent>()));
-    REQUIRE(sig.test(ComponentTypeId<VelocityComponent>()));
+    x2d::World world;
+    x2d::Entity e = world.CreateEntity();
+    world.AddComponent<x2d::TransformComponent>(e, {});
+    world.AddComponent<x2d::VelocityComponent>(e, {});
+    const auto& sig = world.GetSignatures()[x2d::GetIndex(e)];
+    REQUIRE(sig.test(x2d::ComponentTypeId<x2d::TransformComponent>()));
+    REQUIRE(sig.test(x2d::ComponentTypeId<x2d::VelocityComponent>()));
 }
 
 TEST_CASE("Swap erase integrity", "[ecs]")
 {
-    World world;
-    Entity e1 = world.CreateEntity();
-    Entity e2 = world.CreateEntity();
-    world.AddComponent<TransformComponent>(e1, {1.0f,2.0f,0.0f,1.0f});
-    world.AddComponent<TransformComponent>(e2, {3.0f,4.0f,0.0f,1.0f});
+    x2d::World world;
+    x2d::Entity e1 = world.CreateEntity();
+    x2d::Entity e2 = world.CreateEntity();
+    world.AddComponent<x2d::TransformComponent>(e1, {1.0f,2.0f,0.0f,1.0f});
+    world.AddComponent<x2d::TransformComponent>(e2, {3.0f,4.0f,0.0f,1.0f});
 
-    world.RemoveComponent<TransformComponent>(e1);
-    REQUIRE_FALSE(world.HasComponent<TransformComponent>(e1));
-    REQUIRE(world.HasComponent<TransformComponent>(e2));
+    world.RemoveComponent<x2d::TransformComponent>(e1);
+    REQUIRE_FALSE(world.HasComponent<x2d::TransformComponent>(e1));
+    REQUIRE(world.HasComponent<x2d::TransformComponent>(e2));
 }
 
 TEST_CASE("OneFrame clearing", "[ecs]")
 {
-    World world;
-    Entity e = world.CreateEntity();
-    world.AddComponent<OneFrame<DamageEventComponent>>(e, {10});
-    REQUIRE(world.HasComponent<OneFrame<DamageEventComponent>>(e));
+    x2d::World world;
+    x2d::Entity e = world.CreateEntity();
+    world.AddComponent<x2d::OneFrame<x2d::DamageEventComponent>>(e, {10});
+    REQUIRE(world.HasComponent<x2d::OneFrame<x2d::DamageEventComponent>>(e));
     world.EndFrame();
-    REQUIRE_FALSE(world.HasComponent<OneFrame<DamageEventComponent>>(e));
+    REQUIRE_FALSE(world.HasComponent<x2d::OneFrame<x2d::DamageEventComponent>>(e));
 }
 

--- a/tests/PhysicsTest.cpp
+++ b/tests/PhysicsTest.cpp
@@ -7,46 +7,44 @@
 #include "Physics/PhysicsSystem.hpp"
 #include "Physics/RigidBody2DComponent.hpp"
 
-using namespace x2d;
-
 TEST_CASE("EventQueue enqueue/dequeue", "[physics]") {
-    EventQueue<CollisionEvent, 4> q;
+    x2d::EventQueue<x2d::CollisionEvent, 4> q;
     REQUIRE(q.IsEmpty());
     q.Enqueue({1, 2});
-    CollisionEvent ev{};
+    x2d::CollisionEvent ev{};
     REQUIRE(q.Dequeue(ev));
     REQUIRE(ev.a == 1);
     REQUIRE(ev.b == 2);
 }
 
 TEST_CASE("PhysicsSystem detects collision", "[physics]") {
-    World world;
-    Signature sig;
-    sig.set(ComponentTypeId<TransformComponent>());
-    sig.set(ComponentTypeId<RigidBody2DComponent>());
-    sig.set(ComponentTypeId<ColliderAABBComponent>());
+    x2d::World world;
+    x2d::Signature sig;
+    sig.set(x2d::ComponentTypeId<x2d::TransformComponent>());
+    sig.set(x2d::ComponentTypeId<x2d::RigidBody2DComponent>());
+    sig.set(x2d::ComponentTypeId<x2d::ColliderAABBComponent>());
 
-    EventQueue<CollisionEvent> collisions;
-    EventQueue<TriggerEvent> triggers;
-    world.GetSystemManager().RegisterSystem<PhysicsSystem>(ESystemPhase::eSystemPhase_FixedUpdate,
+    x2d::EventQueue<x2d::CollisionEvent> collisions;
+    x2d::EventQueue<x2d::TriggerEvent> triggers;
+    world.GetSystemManager().RegisterSystem<x2d::PhysicsSystem>(x2d::ESystemPhase::eSystemPhase_FixedUpdate,
                                                            sig, collisions, triggers);
 
-    Entity a = world.CreateEntity();
-    world.AddComponent<TransformComponent>(a, {0.0f, 0.0f, 0.0f, 1.0f});
-    world.AddComponent<RigidBody2DComponent>(a, {});
-    world.AddComponent<ColliderAABBComponent>(a, {0.5f, 0.5f, false});
+    x2d::Entity a = world.CreateEntity();
+    world.AddComponent<x2d::TransformComponent>(a, {0.0f, 0.0f, 0.0f, 1.0f});
+    world.AddComponent<x2d::RigidBody2DComponent>(a, {});
+    world.AddComponent<x2d::ColliderAABBComponent>(a, {0.5f, 0.5f, false});
 
-    Entity b = world.CreateEntity();
-    world.AddComponent<TransformComponent>(b, {0.4f, 0.0f, 0.0f, 1.0f});
-    world.AddComponent<RigidBody2DComponent>(b, {});
-    world.AddComponent<ColliderAABBComponent>(b, {0.5f, 0.5f, false});
+    x2d::Entity b = world.CreateEntity();
+    world.AddComponent<x2d::TransformComponent>(b, {0.4f, 0.0f, 0.0f, 1.0f});
+    world.AddComponent<x2d::RigidBody2DComponent>(b, {});
+    world.AddComponent<x2d::ColliderAABBComponent>(b, {0.5f, 0.5f, false});
 
     auto &sm = world.GetSystemManager();
     sm.BuildViews(world);
-    sm.ForEachSystemInPhase(ESystemPhase::eSystemPhase_FixedUpdate,
-                            [](ISystem &sys, const View &view) { sys.Update(view); });
+    sm.ForEachSystemInPhase(x2d::ESystemPhase::eSystemPhase_FixedUpdate,
+                            [](x2d::ISystem &sys, const x2d::View &view) { sys.Update(view); });
 
-    CollisionEvent evt{};
+    x2d::CollisionEvent evt{};
     REQUIRE(collisions.Dequeue(evt));
     REQUIRE(((evt.a == a && evt.b == b) || (evt.a == b && evt.b == a)));
 }

--- a/tests/ProfilerTest.cpp
+++ b/tests/ProfilerTest.cpp
@@ -3,17 +3,15 @@
 #include <cstdio>
 #include <filesystem>
 
-using namespace x2d;
-
 TEST_CASE("Profiler writes csv") {
     const char *path = "profile.csv";
-    Profiler::SetOutput(path);
-    Profiler::SetEnabled(true);
+    x2d::Profiler::SetOutput(path);
+    x2d::Profiler::SetEnabled(true);
     {
         X2D_PROFILE_SCOPE("test");
     }
-    Profiler::SetEnabled(false);
-    Profiler::Flush();
+    x2d::Profiler::SetEnabled(false);
+    x2d::Profiler::Flush();
     FILE *f = nullptr;
 #ifdef _MSC_VER
     fopen_s(&f, path, "r");

--- a/tests/StateMachineTest.cpp
+++ b/tests/StateMachineTest.cpp
@@ -3,12 +3,10 @@
 #include "Application/Application.hpp"
 #include "ECS/SystemManager.hpp"
 
-using namespace x2d;
-
 namespace
 {
 
-struct TrackingState : IState
+struct TrackingState : x2d::IState
 {
     std::string name;
     std::vector<std::string>& log;
@@ -38,11 +36,11 @@ struct TrackingState : IState
     }
 };
 
-struct LogSystem : ISystem
+struct LogSystem : x2d::ISystem
 {
     std::vector<std::string>& log;
     explicit LogSystem(std::vector<std::string>& l) : log(l) {}
-    void Update(const View&) override { log.push_back("update"); }
+    void Update(const x2d::View&) override { log.push_back("update"); }
 };
 
 } // namespace
@@ -50,7 +48,7 @@ struct LogSystem : ISystem
 TEST_CASE("StateMachine transitions", "[fsm]")
 {
     std::vector<std::string> log;
-    StateMachine sm;
+    x2d::StateMachine sm;
 
     sm.PushState(std::make_unique<TrackingState>("Boot", log));
     sm.PushState(std::make_unique<TrackingState>("Menu", log));
@@ -72,10 +70,10 @@ TEST_CASE("StateMachine transitions", "[fsm]")
 TEST_CASE("Application update order", "[fsm]")
 {
     std::vector<std::string> log;
-    Application app;
+    x2d::Application app;
     auto& sm = app.GetStateMachine();
     sm.PushState(std::make_unique<TrackingState>("A", log));
-    app.RegisterSystem<LogSystem>(ESystemPhase::eSystemPhase_Update, {}, log);
+    app.RegisterSystem<LogSystem>(x2d::ESystemPhase::eSystemPhase_Update, {}, log);
 
     app.Update();
 

--- a/tests/SystemPhaseTest.cpp
+++ b/tests/SystemPhaseTest.cpp
@@ -2,26 +2,23 @@
 
 #include "Application/Application.hpp"
 #include "ECS/SystemManager.hpp"
-
-using namespace x2d;
-
 namespace
 {
-struct PhaseLogSystem : ISystem
+struct PhaseLogSystem : x2d::ISystem
 {
     std::vector<int>& log;
     int value;
     PhaseLogSystem(std::vector<int>& l, int v) : log(l), value(v) {}
-    void Update(const View&) override { log.push_back(value); }
+    void Update(const x2d::View&) override { log.push_back(value); }
 };
 } // namespace
 
 TEST_CASE("System phases run in order", "[phase]")
 {
     std::vector<int> log;
-    Application app;
-    app.RegisterSystem<PhaseLogSystem>(ESystemPhase::eSystemPhase_Update, {}, log, 1);
-    app.RegisterSystem<PhaseLogSystem>(ESystemPhase::eSystemPhase_Render, {}, log, 2);
+    x2d::Application app;
+    app.RegisterSystem<PhaseLogSystem>(x2d::ESystemPhase::eSystemPhase_Update, {}, log, 1);
+    app.RegisterSystem<PhaseLogSystem>(x2d::ESystemPhase::eSystemPhase_Render, {}, log, 2);
 
     app.Update();
 


### PR DESCRIPTION
## Summary
- clean up tests to follow style guide
- remove `using namespace x2d` and fully qualify names

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687ddfc72940832c95e97490d626e339